### PR TITLE
Setting up the FastAPI with a Mock Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# qxf2-survey
-Home for Qxf2's help survey
+# Sample API for Qxf2-Survey
+
+A sample API endpoint created using FastAPI and Uvicorn for returning a mock JSON Data as a message.
+
+## Setup
+
+1. Install the Virtual Environment: `virtualenv env`
+2. Activate the Virtual Environment: `activate`
+3. Install the requirements `pip install -r requirements.txt`
+4. Start the app `uvicorn main:app`
+5. Goto `http://127.0.0.1:8000/` to see a message displayed.

--- a/main.py
+++ b/main.py
@@ -20,3 +20,4 @@ if __name__ == "__main__":
         debug=True,
         reload=True
     )
+    

--- a/main.py
+++ b/main.py
@@ -1,0 +1,22 @@
+"""
+Sample Endpoint for Qxf2 Survey Application
+"""
+
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    "Returns the Message for Mock Data"
+    return {"msg": "Mock Data for the Survey"}
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        access_log=False,
+        port=5000,
+        debug=True,
+        reload=True
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.61.0
+uvicorn==0.11.8


### PR DESCRIPTION
## Description

Creating a sample API with FastAPI Framework which returns a mock JSON Message on a Uvicorn Server. The sample API would have just one endpoint for now and is required to set up the basic operations before we move ahead with integrating a database layer to our application.

## Issue Reference

The Jira Ticket is available [here](https://qxf2services.atlassian.net/jira/software/projects/QELO/boards/32?selectedIssue=QELO-16)

## Primary Changes Done

- Added `main.py` file to implement a Mock Server
- Made a single endpoint to return a JSON Message
- Added Requirements and README