### PR TITLE
Fixed a bug in the navigation bar component

### DIFF
--- a/frontend/src/pages/ConfirmationPage.js
+++ b/frontend/src/pages/ConfirmationPage.js
@@ -1,5 +1,6 @@
 import React from "react";
 import axios from "axios";
+import Button from "react-bootstrap/Button";
 
 function ConfirmationPage(props) {
   var email = props.state.email;
@@ -42,6 +43,18 @@ function ConfirmationPage(props) {
       <p><b>Who helped you:</b> {whoHelp.map(whoHelp => whoHelp.label).join(', ')}</p>
       <p><b>Whom did you help:</b> {whomHelped.map(whomHelped => whomHelped.label).join(', ')} </p>
       <p><b>Tags:</b> {tagList} </p>
+      <div className="col-md-4 offset-md-4">
+        <Button
+          variant="primary"
+          size="lg"
+          block
+          button
+          disabled={props.step.isLast()}
+          onClick={props.next}
+        >
+          Back to Survey
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SurveyPage.js
+++ b/frontend/src/pages/SurveyPage.js
@@ -9,6 +9,7 @@ function SurveyPage() {
       <Steps>
         <Step component={QuestionForm} />
         <Step component={ConfirmationPage} />
+        <Step component={QuestionForm} />
       </Steps>
     </div>
   );


### PR DESCRIPTION
Branch: Fix_NavBar_Bug
---
**Modified files(s):**
1. frontend/src/pages/ConfirmationPage.js
2. frontend/src/pages/SurveyPage.js

**About the bug:**
---
After submitting the survey, we get to the confirmation page. When tried to get back to survey page while on this confirmation page, the survey tab in the navigation bar wasn't operational and was resubmitting the survey everytime the survey tab was clicked. 

![ghghg](https://user-images.githubusercontent.com/67339285/101602232-cc40d780-3a23-11eb-904a-4e21d41cacca.gif)

**Fix:**
---
1. Added another step in **SurveyPage.js**
2. Added a **Back to Survey** button in the confirmation page so that on clicking this button would take the user back to survey page. 

![fixed_bug](https://user-images.githubusercontent.com/67339285/101603470-9ef52900-3a25-11eb-83a9-013a53aff837.gif)


