### PR TITLE
Backup neo4j on s3

### DIFF
--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -21,6 +21,12 @@ jobs:
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-        target: "survey_db.dump"
+        target: "/home/runner/work/qxf2-survey/qxf2-survey/backup/"
+    - name: list files again
+      run: |
+        pwd
+        cd backup
+        pwd
+        ls 
 
         

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,6 +7,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: list files
+      run: |
+        ls -al
     - name: copy file via ssh key
       uses: appleboy/scp-action@master
       with:
@@ -17,7 +20,5 @@ jobs:
           pwd
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
         target: "survey_db.dump"
-    - name: list files
-      run: |
-        ls -al
+
         

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -9,15 +9,17 @@ jobs:
     steps:
     - name: list files
       run: |
+        mkdir backup
         ls -al
+        pwd
+        cd backup
+        pwd      
     - name: copy file via ssh key
       uses: appleboy/scp-action@master
       with:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
-        script:  |
-          pwd
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
         target: "survey_db.dump"
 

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,26 +7,22 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: list files
-      run: |
-        mkdir backup
-        ls -al
-        pwd
-        cd backup
-        pwd      
-    - name: copy file via ssh key
-      uses: appleboy/scp-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.PROD_KEY }}
-        source: "survey_db_backup/neo4j-20220210.dump"
-        target: "test.dump"
-    - name: list files again
-      run: |
-        pwd
-        cd backup
-        pwd
-        ls 
+      - name: Check out repository
+        uses: actions/checkout@master
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          insecure_ignore_fingerprint: true
+          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+          target: "survey_db_backup.dump"
+
+      - name: list files again
+        run: |
+          pwd
+          ls
 
         

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -14,8 +14,20 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PROD_KEY }}
           script:  |
-            sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
             sudo service neo4j stop
+            sudo neo4j-admin check-consistency --database=neo4j --report-dir=/home/ubuntu/survey_db_backup/report
+            DIR="/home/ubuntu/survey_db_backup/report"
+            if [ -d "$DIR" ]
+            then
+              if [ "$(ls -A $DIR)" ]; then
+                echo "Take action $DIR is not Empty"
+              else
+                echo "$DIR is Empty"
+              fi
+            else
+              echo "Directory $DIR not found."
+            fi          
+            sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
             sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
             ls /home/ubuntu/survey_db_backup
             sudo service neo4j start

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -1,0 +1,21 @@
+name: Survey Backup
+on:
+  push:
+    branches:
+      - backup-neo4j-on-s3
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: SSH to EC2 instance
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.PROD_KEY }}
+        script:  |
+          sudo service neo4j stop
+          today=$(date +"%Y%m%d")
+          filename="neo4j-$today.dump"
+          sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
+          ls /home/ubuntu/survey_db_backup

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -14,10 +14,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PROD_KEY }}
           script:  |
+            sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
             sudo service neo4j stop
-            today=$(date +"%Y%m%d")
-            filename="neo4j-$today.dump"
-            sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
+            sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
             ls /home/ubuntu/survey_db_backup
             sudo service neo4j start
 
@@ -31,7 +30,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PROD_KEY }}
           insecure_ignore_fingerprint: true
-          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+          source: "/home/ubuntu/survey_db_backup/survey_db.dump"
           target: "survey_db_backup.dump"
 
       - name: list files again

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -67,24 +67,25 @@ jobs:
             SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
 
   run-if-failed:
-    runs-on: ubuntu-latest
-    needs: [job1]
-    if: always() && (needs.job1.result == 'failure')
-    steps:
-      - name: Copy the inconsistency report from EC2 instance to container
-        uses: actions/checkout@master
-      - name: Download file via SSH
-        uses: nicklasfrahm/scp-action@main
-        with:
-          direction: download
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          insecure_ignore_fingerprint: true
-          source: "/home/ubuntu/survey_db_backup/report/*"
-          target: "report/"
+    deploy:
+      runs-on: ubuntu-latest
+      needs: [job1]
+      if: always() && (needs.job1.result == 'failure')
+      steps:
+        - name: Copy the inconsistency report from EC2 instance to container
+          uses: actions/checkout@master
+        - name: Download file via SSH
+          uses: nicklasfrahm/scp-action@main
+          with:
+            direction: download
+            host: ${{ secrets.HOST }}
+            username: ${{ secrets.USERNAME }}
+            key: ${{ secrets.PROD_KEY }}
+            insecure_ignore_fingerprint: true
+            source: "/home/ubuntu/survey_db_backup/report/*"
+            target: "report/"
 
-      - name: Move the backup file into a new directory
-        run: |
-          pwd
-          ls -a
+        - name: Move the backup file into a new directory
+          run: |
+            pwd
+            ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,27 +7,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: SSH to EC2 instance
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.PROD_KEY }}
-        script:  |
-          sudo service neo4j stop
-          today=$(date +"%Y%m%d")
-          filename="neo4j-$today.dump"
-          sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
-          ls /home/ubuntu/survey_db_backup
-    - name: Download file via SSH
-      uses: nicklasfrahm/scp-action@main
-      with:
-        direction: download
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.PROD_KEY }}
-        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-        target: "survey_db_backup.dump"
-    - name: list files
-      run: |
-        ls -al
+      - name: Check out repository
+        uses: actions/checkout@master
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+          target: "survey_db_backup.dump"
+      - name: list files
+        run: |
+          ls -al

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - backup-neo4j-on-s3
-      
-jobs:
+
+job:
   deploy:
     runs-on: ubuntu-latest
     steps:
@@ -64,4 +64,26 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
           SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
-        
+
+  run-if-failed:
+    runs-on: ubuntu-latest
+    needs: [job]
+    if: always() && (needs.job.result == 'failure')
+    steps:
+      - name: Copy the inconsistency report from EC2 instance to container
+        uses: actions/checkout@master
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          insecure_ignore_fingerprint: true
+          source: "/home/ubuntu/survey_db_backup/report/*"
+          target: "report/"
+
+      - name: Move the backup file into a new directory
+        run: |
+          pwd
+          ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - backup-neo4j-on-s3
+      
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -82,7 +82,7 @@ jobs:
             key: ${{ secrets.PROD_KEY }}
             insecure_ignore_fingerprint: true
             source: "/home/ubuntu/survey_db_backup/report/*"
-            target: "report/"
+            target: "inconsistency_report.txt"
 
         - name: Move the backup file into a new directory
           run: |

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,6 +7,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: SSH to EC2 instance
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.PROD_KEY }}
+        script:  |
+          sudo service neo4j stop
+          today=$(date +"%Y%m%d")
+          filename="neo4j-$today.dump"
+          sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
+          ls /home/ubuntu/survey_db_backup
+          sudo service neo4j start
+
       - name: Check out repository
         uses: actions/checkout@master
       - name: Download file via SSH
@@ -24,11 +38,8 @@ jobs:
         run: |
           pwd
           mkdir backup
-          ls
           mv survey_db_backup.dump backup
-          cd backup
-          pwd
-          ls -l *   
+          ls backup/
       - name: Connect s3 bucket
         uses: jakejarvis/s3-sync-action@master
         env:

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -5,7 +5,7 @@ on:
       - backup-neo4j-on-s3
 
 jobs:
-  job1:
+  database-backup:
     runs-on: ubuntu-latest
     steps:
       - name: SSH to EC2 instance and create survey database backup
@@ -67,13 +67,13 @@ jobs:
 
   run-if-failed:
       name: "run if initial job failed"
-      needs: [job1]
+      needs: [database-backup]
       runs-on: ubuntu-latest
-      if: always() && (needs.job1.result == 'failure')
+      if: always() && (needs.database-backup.result == 'failure')
       steps:
         - name: Copy the inconsistency report from EC2 instance to container
           uses: actions/checkout@master
-        - name: Download file via SSH
+        - name: Download inconsistency report via SSH
           uses: nicklasfrahm/scp-action@main
           with:
             direction: download
@@ -84,7 +84,27 @@ jobs:
             source: "/home/ubuntu/survey_db_backup/report/*"
             target: "inconsistency_report.txt"
 
-        - name: Move the backup file into a new directory
+        - name: Move the report into a new directory
           run: |
             pwd
             ls -a
+            mkdir reports
+            mv inconsistency_report.txt reports
+
+        - name: Connect s3 bucket and save the report
+          uses: jakejarvis/s3-sync-action@master
+          env:
+            AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+            SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/reports'
+
+        - name: SSH to EC2 instance and delete the report
+          uses: appleboy/ssh-action@master
+          with:
+            host: ${{ secrets.HOST }}
+            username: ${{ secrets.USERNAME }}
+            key: ${{ secrets.PROD_KEY }}
+            script:  |
+              sudo rm /home/ubuntu/survey_db_backup/report/*

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,19 +7,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: SSH to EC2 instance
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.PROD_KEY }}
-        script:  |
-          sudo service neo4j stop
-          today=$(date +"%Y%m%d")
-          filename="neo4j-$today.dump"
-          sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
-          ls /home/ubuntu/survey_db_backup
-          sudo service neo4j start
+      - name: SSH to EC2 instance
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          script:  |
+            sudo service neo4j stop
+            today=$(date +"%Y%m%d")
+            filename="neo4j-$today.dump"
+            sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
+            ls /home/ubuntu/survey_db_backup
+            sudo service neo4j start
 
       - name: Check out repository
         uses: actions/checkout@master

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -13,6 +13,8 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
+        script:  |
+          pwd
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
         target: "survey_db.dump"
     - name: list files

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -19,15 +19,16 @@ jobs:
           filename="neo4j-$today.dump"
           sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
           ls /home/ubuntu/survey_db_backup
-    - name: Download backup file
-      uses: appleboy/scp-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        port: ${{ secrets.PORT }}
-        key: ${{ secrets.PROD_KEY }}  
-        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-        target: "/home/"
-    - name: list files in directory
-      run: |
-        ls -a
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          port: ${{ secrets.port }}
+          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+          target: "survey_db_backup.dump"
+      - name: list files
+        run: |
+          ls -al

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -26,7 +26,6 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
-        port: ${{ secrets.port }}
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
         target: "survey_db_backup.dump"
     - name: list files

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -6,65 +6,64 @@ on:
 
 jobs:
   job1:
-    deploy:
-      runs-on: ubuntu-latest
-      steps:
-        - name: SSH to EC2 instance and create survey database backup
-          uses: appleboy/ssh-action@master
-          with:
-            host: ${{ secrets.HOST }}
-            username: ${{ secrets.USERNAME }}
-            key: ${{ secrets.PROD_KEY }}
-            script:  |
-              sudo service neo4j stop
-              sudo neo4j-admin check-consistency --database=neo4j --report-dir=/home/ubuntu/survey_db_backup/report
-              DIR="/home/ubuntu/survey_db_backup/report"
-              if [ -d "$DIR" ]
-              then
-                if [ "$(ls -A $DIR)" ]; then
-                  echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
-                  sudo service neo4j start
-                  exit 1
-                else
-                  echo "$DIR is Empty which means there are no inconsistencies"
-                  sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
-                  sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
-                  ls /home/ubuntu/survey_db_backup
-                  sudo service neo4j start
-                fi
-              else
-                echo "Directory $DIR not found."
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH to EC2 instance and create survey database backup
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          script:  |
+            sudo service neo4j stop
+            sudo neo4j-admin check-consistency --database=neo4j --report-dir=/home/ubuntu/survey_db_backup/report
+            DIR="/home/ubuntu/survey_db_backup/report"
+            if [ -d "$DIR" ]
+            then
+              if [ "$(ls -A $DIR)" ]; then
+                echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
                 sudo service neo4j start
-              fi          
+                exit 1
+              else
+                echo "$DIR is Empty which means there are no inconsistencies"
+                sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
+                sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
+                ls /home/ubuntu/survey_db_backup
+                sudo service neo4j start
+              fi
+            else
+              echo "Directory $DIR not found."
+              sudo service neo4j start
+            fi          
 
-        - name: Copy the backup file from Ec2 instance
-          uses: actions/checkout@master
-        - name: Download file via SSH
-          uses: nicklasfrahm/scp-action@main
-          with:
-            direction: download
-            host: ${{ secrets.HOST }}
-            username: ${{ secrets.USERNAME }}
-            key: ${{ secrets.PROD_KEY }}
-            insecure_ignore_fingerprint: true
-            source: "/home/ubuntu/survey_db_backup/survey_db.dump"
-            target: "survey_db_backup.dump"
+      - name: Copy the backup file from Ec2 instance
+        uses: actions/checkout@master
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          insecure_ignore_fingerprint: true
+          source: "/home/ubuntu/survey_db_backup/survey_db.dump"
+          target: "survey_db_backup.dump"
 
-        - name: Move the backup file into a new directory
-          run: |
-            pwd
-            mkdir backup
-            mv survey_db_backup.dump backup
-            ls backup/
-            
-        - name: Connect s3 bucket
-          uses: jakejarvis/s3-sync-action@master
-          env:
-            AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
-            SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
+      - name: Move the backup file into a new directory
+        run: |
+          pwd
+          mkdir backup
+          mv survey_db_backup.dump backup
+          ls backup/
+          
+      - name: Connect s3 bucket
+        uses: jakejarvis/s3-sync-action@master
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+          SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
 
   run-if-failed:
       name: "run if initial job failed"

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -20,17 +20,19 @@ jobs:
             if [ -d "$DIR" ]
             then
               if [ "$(ls -A $DIR)" ]; then
-                echo "Take action $DIR is not Empty"
+                echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
+                sudo service neo4j start
               else
-                echo "$DIR is Empty"
+                echo "$DIR is Empty which means there are no inconsistencies"
+                sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
+                sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
+                ls /home/ubuntu/survey_db_backup
+                sudo service neo4j start
               fi
             else
               echo "Directory $DIR not found."
+              sudo service neo4j start
             fi          
-            sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
-            sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
-            ls /home/ubuntu/survey_db_backup
-            sudo service neo4j start
 
       - name: Check out repository
         uses: actions/checkout@master

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -4,86 +4,87 @@ on:
     branches:
       - backup-neo4j-on-s3
 
-job:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: SSH to EC2 instance and create survey database backup
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          script:  |
-            sudo service neo4j stop
-            sudo neo4j-admin check-consistency --database=neo4j --report-dir=/home/ubuntu/survey_db_backup/report
-            DIR="/home/ubuntu/survey_db_backup/report"
-            if [ -d "$DIR" ]
-            then
-              if [ "$(ls -A $DIR)" ]; then
-                echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
-                sudo service neo4j start
-                exit 1
+jobs:
+  job1:
+    deploy:
+      runs-on: ubuntu-latest
+      steps:
+        - name: SSH to EC2 instance and create survey database backup
+          uses: appleboy/ssh-action@master
+          with:
+            host: ${{ secrets.HOST }}
+            username: ${{ secrets.USERNAME }}
+            key: ${{ secrets.PROD_KEY }}
+            script:  |
+              sudo service neo4j stop
+              sudo neo4j-admin check-consistency --database=neo4j --report-dir=/home/ubuntu/survey_db_backup/report
+              DIR="/home/ubuntu/survey_db_backup/report"
+              if [ -d "$DIR" ]
+              then
+                if [ "$(ls -A $DIR)" ]; then
+                  echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
+                  sudo service neo4j start
+                  exit 1
+                else
+                  echo "$DIR is Empty which means there are no inconsistencies"
+                  sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
+                  sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
+                  ls /home/ubuntu/survey_db_backup
+                  sudo service neo4j start
+                fi
               else
-                echo "$DIR is Empty which means there are no inconsistencies"
-                sudo rm /home/ubuntu/survey_db_backup/survey_db.dump
-                sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/survey_db.dump
-                ls /home/ubuntu/survey_db_backup
+                echo "Directory $DIR not found."
                 sudo service neo4j start
-              fi
-            else
-              echo "Directory $DIR not found."
-              sudo service neo4j start
-            fi          
+              fi          
 
-      - name: Copy the backup file from Ec2 instance
-        uses: actions/checkout@master
-      - name: Download file via SSH
-        uses: nicklasfrahm/scp-action@main
-        with:
-          direction: download
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          insecure_ignore_fingerprint: true
-          source: "/home/ubuntu/survey_db_backup/survey_db.dump"
-          target: "survey_db_backup.dump"
+        - name: Copy the backup file from Ec2 instance
+          uses: actions/checkout@master
+        - name: Download file via SSH
+          uses: nicklasfrahm/scp-action@main
+          with:
+            direction: download
+            host: ${{ secrets.HOST }}
+            username: ${{ secrets.USERNAME }}
+            key: ${{ secrets.PROD_KEY }}
+            insecure_ignore_fingerprint: true
+            source: "/home/ubuntu/survey_db_backup/survey_db.dump"
+            target: "survey_db_backup.dump"
 
-      - name: Move the backup file into a new directory
-        run: |
-          pwd
-          mkdir backup
-          mv survey_db_backup.dump backup
-          ls backup/
-          
-      - name: Connect s3 bucket
-        uses: jakejarvis/s3-sync-action@master
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
-          SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
+        - name: Move the backup file into a new directory
+          run: |
+            pwd
+            mkdir backup
+            mv survey_db_backup.dump backup
+            ls backup/
+            
+        - name: Connect s3 bucket
+          uses: jakejarvis/s3-sync-action@master
+          env:
+            AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+            SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
 
-  run-if-failed:
-    runs-on: ubuntu-latest
-    needs: [job]
-    if: always() && (needs.job.result == 'failure')
-    steps:
-      - name: Copy the inconsistency report from EC2 instance to container
-        uses: actions/checkout@master
-      - name: Download file via SSH
-        uses: nicklasfrahm/scp-action@main
-        with:
-          direction: download
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          insecure_ignore_fingerprint: true
-          source: "/home/ubuntu/survey_db_backup/report/*"
-          target: "report/"
+    run-if-failed:
+      runs-on: ubuntu-latest
+      needs: [job1]
+      if: always() && (needs.job1.result == 'failure')
+      steps:
+        - name: Copy the inconsistency report from EC2 instance to container
+          uses: actions/checkout@master
+        - name: Download file via SSH
+          uses: nicklasfrahm/scp-action@main
+          with:
+            direction: download
+            host: ${{ secrets.HOST }}
+            username: ${{ secrets.USERNAME }}
+            key: ${{ secrets.PROD_KEY }}
+            insecure_ignore_fingerprint: true
+            source: "/home/ubuntu/survey_db_backup/report/*"
+            target: "report/"
 
-      - name: Move the backup file into a new directory
-        run: |
-          pwd
-          ls -a
+        - name: Move the backup file into a new directory
+          run: |
+            pwd
+            ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -19,16 +19,16 @@ jobs:
           filename="neo4j-$today.dump"
           sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
           ls /home/ubuntu/survey_db_backup
-      - name: Download file via SSH
-        uses: nicklasfrahm/scp-action@main
-        with:
-          direction: download
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          port: ${{ secrets.port }}
-          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-          target: "survey_db_backup.dump"
-      - name: list files
-        run: |
-          ls -al
+    - name: Download file via SSH
+      uses: nicklasfrahm/scp-action@main
+      with:
+        direction: download
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.PROD_KEY }}
+        port: ${{ secrets.port }}
+        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+        target: "survey_db_backup.dump"
+    - name: list files
+      run: |
+        ls -al

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -67,9 +67,9 @@ jobs:
             SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
 
   run-if-failed:
-    deploy:
-      runs-on: ubuntu-latest
+      name: "run if initial job failed"
       needs: [job1]
+      runs-on: ubuntu-latest
       if: always() && (needs.job1.result == 'failure')
       steps:
         - name: Copy the inconsistency report from EC2 instance to container

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -23,6 +23,15 @@ jobs:
       - name: list files again
         run: |
           pwd
+          mkdir backup
           ls
-
+          mv survey_db_backup.dump backup
+      - name: Connect s3 bucket
+        uses: jakejarvis/s3-sync-action@master
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+          SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
         

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -66,25 +66,25 @@ jobs:
             AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
             SOURCE_DIR: '/home/runner/work/qxf2-survey/qxf2-survey/backup'
 
-    run-if-failed:
-      runs-on: ubuntu-latest
-      needs: [job1]
-      if: always() && (needs.job1.result == 'failure')
-      steps:
-        - name: Copy the inconsistency report from EC2 instance to container
-          uses: actions/checkout@master
-        - name: Download file via SSH
-          uses: nicklasfrahm/scp-action@main
-          with:
-            direction: download
-            host: ${{ secrets.HOST }}
-            username: ${{ secrets.USERNAME }}
-            key: ${{ secrets.PROD_KEY }}
-            insecure_ignore_fingerprint: true
-            source: "/home/ubuntu/survey_db_backup/report/*"
-            target: "report/"
+  run-if-failed:
+    runs-on: ubuntu-latest
+    needs: [job1]
+    if: always() && (needs.job1.result == 'failure')
+    steps:
+      - name: Copy the inconsistency report from EC2 instance to container
+        uses: actions/checkout@master
+      - name: Download file via SSH
+        uses: nicklasfrahm/scp-action@main
+        with:
+          direction: download
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PROD_KEY }}
+          insecure_ignore_fingerprint: true
+          source: "/home/ubuntu/survey_db_backup/report/*"
+          target: "report/"
 
-        - name: Move the backup file into a new directory
-          run: |
-            pwd
-            ls -a
+      - name: Move the backup file into a new directory
+        run: |
+          pwd
+          ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -1,7 +1,8 @@
 name: Survey Backup
 on:
-  schedule:
-    - cron: "0 0 * * *"   
+  push:
+    branches:
+      - backup-neo4j-on-s3
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,6 +22,7 @@ jobs:
               if [ "$(ls -A $DIR)" ]; then
                 echo "Take action $DIR is not Empty, which means there are inconsistencies in the database"
                 sudo service neo4j start
+                exit 1
               else
                 echo "$DIR is Empty which means there are no inconsistencies"
                 sudo rm /home/ubuntu/survey_db_backup/survey_db.dump

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -7,17 +7,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@master
-      - name: Download file via SSH
-        uses: nicklasfrahm/scp-action@main
-        with:
-          direction: download
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PROD_KEY }}
-          source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-          target: "survey_db_backup.dump"
-      - name: list files
-        run: |
-          ls -al
+    - name: copy file via ssh key
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.PROD_KEY }}
+        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+        target: "survey_db.dump"
+    - name: list files
+      run: |
+        ls -al
+        

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -1,8 +1,7 @@
 name: Survey Backup
 on:
-  push:
-    branches:
-      - backup-neo4j-on-s3
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
   database-backup:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - backup-neo4j-on-s3
-
 jobs:
   database-backup:
     runs-on: ubuntu-latest
@@ -35,7 +34,6 @@ jobs:
               echo "Directory $DIR not found."
               sudo service neo4j start
             fi          
-
       - name: Copy the backup file from Ec2 instance
         uses: actions/checkout@master
       - name: Download file via SSH

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -19,3 +19,15 @@ jobs:
           filename="neo4j-$today.dump"
           sudo neo4j-admin dump --database=neo4j --to=/home/ubuntu/survey_db_backup/$filename
           ls /home/ubuntu/survey_db_backup
+    - name: Download backup file
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        port: ${{ secrets.PORT }}
+        key: ${{ secrets.PROD_KEY }}  
+        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
+        target: "survey_db_backup.dump"
+    - name: list files in directory
+      run: |
+        ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -21,7 +21,7 @@ jobs:
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
         source: "survey_db_backup/neo4j-20220210.dump"
-        target: "/home/runner/work/qxf2-survey/qxf2-survey/backup/test.dump"
+        target: "test.dump"
     - name: list files again
       run: |
         pwd

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -1,13 +1,12 @@
 name: Survey Backup
 on:
-  push:
-    branches:
-      - backup-neo4j-on-s3
+  schedule:
+    - cron: "0 0 * * *"   
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: SSH to EC2 instance
+      - name: SSH to EC2 instance and create survey database backup
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}
@@ -34,7 +33,7 @@ jobs:
               sudo service neo4j start
             fi          
 
-      - name: Check out repository
+      - name: Copy the backup file from Ec2 instance
         uses: actions/checkout@master
       - name: Download file via SSH
         uses: nicklasfrahm/scp-action@main
@@ -47,12 +46,13 @@ jobs:
           source: "/home/ubuntu/survey_db_backup/survey_db.dump"
           target: "survey_db_backup.dump"
 
-      - name: list files again
+      - name: Move the backup file into a new directory
         run: |
           pwd
           mkdir backup
           mv survey_db_backup.dump backup
           ls backup/
+          
       - name: Connect s3 bucket
         uses: jakejarvis/s3-sync-action@master
         env:

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -26,6 +26,9 @@ jobs:
           mkdir backup
           ls
           mv survey_db_backup.dump backup
+          cd backup
+          pwd
+          ls -l *   
       - name: Connect s3 bucket
         uses: jakejarvis/s3-sync-action@master
         env:

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -27,7 +27,7 @@ jobs:
         port: ${{ secrets.PORT }}
         key: ${{ secrets.PROD_KEY }}  
         source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-        target: "survey_db_backup.dump"
+        target: "/home/"
     - name: list files in directory
       run: |
         ls -a

--- a/.github/workflows/cron-job-db-backup.yml
+++ b/.github/workflows/cron-job-db-backup.yml
@@ -20,8 +20,8 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PROD_KEY }}
-        source: "/home/ubuntu/survey_db_backup/neo4j-20220210.dump"
-        target: "/home/runner/work/qxf2-survey/qxf2-survey/backup/"
+        source: "survey_db_backup/neo4j-20220210.dump"
+        target: "/home/runner/work/qxf2-survey/qxf2-survey/backup/test.dump"
     - name: list files again
       run: |
         pwd


### PR DESCRIPTION
In this PR I have added a Github Action to check the DB consistency and  backup the survey DB to the database
What the workflow does:
- SSH into the survey instance and stop the database
-  Check for the database consistency
- If the database is inconsistent:
  - Save the inconsistency report to the directory `/home/ubuntu/survey_db_backup/report`
  -  Start the database
  -  Fail the backup job
  -  Run another job that is triggered when the backup job fails
  - This job copies the inconsistency report from `/home/ubuntu/survey_db_backup/report/' to S3 bucket
  - SSH into the survey instance and delete the report in `/home/ubuntu/survey_db_backup/report/'
- If the database is consistent:
  - Create a backup of the database into the directory `/home/ubuntu/survey_db_backup/`
  - Start the database
  - copy the  database backup file into S3 bucket
- This is a cron job that runs everyday at 00:00:00 GMT ie: approx 5:30 IST


