### PR TITLE
Optimize query

### DIFF
--- a/backend/app/db/queries/cypher.py
+++ b/backend/app/db/queries/cypher.py
@@ -39,7 +39,7 @@ GET_USER_NAME = "MATCH (e:Employees)\
 GET_USER_ID = "MATCH (e:Employees)\
                RETURN e.ID, e.email"
 
-GET_ACTIVE_USER_ID =  "MATCH (e:Employees)\
+GET_ACTIVE_USER_ID = "MATCH (e:Employees)\
                        WHERE e.status='Y'\
                        RETURN e.ID"
 
@@ -51,7 +51,7 @@ SET_USER_STATUS = "MATCH (e:Employees)\
                    WHERE e.email=$email\
                    SET e.status=$status"
 
-GET_ACTIVE_USER_NAME =  "MATCH (e:Employees)\
+GET_ACTIVE_USER_NAME = "MATCH (e:Employees)\
                          WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
                          RETURN e.fullName as name"
 
@@ -59,7 +59,7 @@ GET_ACTIVE_USER_LIST = "MATCH (e:Employees)\
                         WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
                         RETURN e.fullName as name, e.ID as id"
 
-GET_ACTIVE_USER_IDS  =   "MATCH (e:Employees)\
+GET_ACTIVE_USER_IDS = "MATCH (e:Employees)\
                           WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
                           RETURN e.ID as id"
 
@@ -102,11 +102,13 @@ GET_ALL_USERS = "MATCH (e:Employees)\
 
 GET_USERS_BY_ID = "MATCH (e:Employees { ID: $id }) RETURN e"
 
-CHECK_IF_RESPONDED = ["MATCH (a:Employees)-[x:GIVEN]->(b:Employees) WHERE $date in x.helpgiven return a.ID",
-                      "MATCH (a:Employees)-[y:TAKEN]->(b:Employees) WHERE $date in y.helptaken return a.ID",
-                      "MATCH (a:Employees)-[z:KNOWS]-(b:Technology) WHERE $date in z.learnt_dates return a.ID"]
+CHECK_IF_RESPONDED = [
+    "MATCH (a:Employees)-[x:GIVEN]->(b:Employees) WHERE $date in x.helpgiven return a.ID",
+    "MATCH (a:Employees)-[y:TAKEN]->(b:Employees) WHERE $date in y.helptaken return a.ID",
+    "MATCH (a:Employees)-[z:KNOWS]-(b:Technology) WHERE $date in z.learnt_dates return a.ID",
+]
 
-TECHNOLOGIES_LEARNT_ON_PARTICULAR_WEEK =  "MATCH (a:Employees)-[z:KNOWS]-(b:Technology)\
+TECHNOLOGIES_LEARNT_ON_PARTICULAR_WEEK = "MATCH (a:Employees)-[z:KNOWS]-(b:Technology)\
                                            WHERE $date_monday in z.learnt_dates OR $date_friday in z.learnt_dates\
                                            WITH DISTINCT[a.fullName,b.technology_name] AS output\
                                            RETURN output[0] AS Name,output[1] AS Technology"
@@ -127,32 +129,31 @@ QELO_RESPONSE = "MATCH (m:Employees)-[r]->(n:Employees) RETURN m.ID AS responden
 	             WHEN 'GIVEN' THEN 2\
                  END AS question_no, n.fullName as answer"
 
-QELO_RESPONSE_BETWEEN_DATES =  "MATCH (m:Employees)-[r]->(n:Employees)\
-                                UNWIND [r.helpgiven,r.helptaken] AS list_helpdates\
-                                UNWIND list_helpdates as helpdate\
-                                WITH DISTINCT(helpdate)\
-                                WHERE date(helpdate)>=date($start_date)\
-                                AND date(helpdate)<=date($end_date)\
-                                MATCH (m:Employees)-[r]->(n:Employees)\
-                                WHERE helpdate in r.helpgiven\
-                                OR helpdate in r.helptaken\
-                                WITH distinct [m.ID,helpdate,CASE type(r)\
-                                WHEN 'TAKEN' THEN 1\
-                                WHEN 'GIVEN' THEN 2\
-                                END,n.fullName] as output\
-                                RETURN output[0] AS respondent_id, output[1] AS date,\
-                                output[2] AS question_no, output[3] AS answer"
+#Query to get responses between two given dates
+QELO_RESPONSE_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Employees)\
+                                    UNWIND [r.helpgiven,r.helptaken] AS list_helpdates\
+                                    UNWIND list_helpdates AS helpdate\
+                                    WITH DISTINCT(helpdate)\
+                                    WHERE date(helpdate)>=date($start_date)\
+                                    AND date(helpdate)<=date($end_date)\
+                                    MATCH (m:Employees)-[r]->(n:Employees)\
+                                    WHERE helpdate IN r.helpgiven\
+                                    OR helpdate IN r.helptaken\
+                                    WITH DISTINCT[m.ID,helpdate,CASE type(r)\
+                                    WHEN 'TAKEN' THEN 1\
+                                    WHEN 'GIVEN' THEN 2\
+                                    END,n.fullName] AS output\
+                                    RETURN output[0] AS respondent_id, output[1] AS date,\
+                                    output[2] AS question_no, output[3] AS answer"
 
-
-QELO_TECHNOLOGY_BETWEEN_DATES =    "MATCH (m:Employees)-[r]->(n:Technology)\
+#Query to get  technologies learnt between two given dates
+QELO_TECHNOLOGY_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Technology)\
                                     UNWIND r.learnt_dates\
-                                    AS learn WITH distinct(learn)\
-                                    WHERE date(learn)>=date($start_date)\
-                                    AND date(learn)<=date($end_date)\
+                                    AS learnt_date WITH DISTINCT(learnt_date)\
+                                    WHERE date(learnt_date)>=date($start_date)\
+                                    AND date(learnt_date)<=date($end_date)\
                                     MATCH (m:Employees)-[r]->(n:Technology)\
-                                    WHERE learn in r.learnt_dates\
-                                    WITH DISTINCT[m.ID,n.technology_name,learn] AS\
+                                    WHERE learnt_date IN r.learnt_dates\
+                                    WITH DISTINCT[m.ID,n.technology_name,learnt_date] AS\
                                     output RETURN output[0] AS respondent_id,\
                                     output[1] AS technology,output[2] AS date"
-
-                                    

--- a/backend/app/db/queries/cypher.py
+++ b/backend/app/db/queries/cypher.py
@@ -156,3 +156,33 @@ QELO_TECHNOLOGY_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Technology)\
                                  WITH DISTINCT[m.ID,n.technology_name,learn] AS\
                                  output RETURN output[0] AS respondent_id,\
                                  output[1] AS technology,output[2] AS date"
+
+QELO_RESPONSE_BETWEEN_DATES_OPTMIZED = "MATCH (m:Employees)-[r]->(n:Employees) WITH\
+                                        CASE type(r)\
+                                        WHEN 'GIVEN' THEN r.helpgiven\
+                                        WHEN 'TAKEN' THEN r.helptaken\
+                                        END AS dates\
+                                        WITH dates UNWIND dates AS helpdate\
+                                        WITH DISTINCT(helpdate)\
+                                        WHERE date(helpdate)>=date($start_date)\
+                                        AND date(helpdate)<=date($end_date)\
+                                        MATCH (m:Employees)-[r]->(n:Employees)\
+                                        WHERE helpdate in r.helpgiven\
+                                        OR helpdate in r.helptaken\
+                                        WITH distinct [m.ID,helpdate,CASE type(r)\
+                                        WHEN 'TAKEN' THEN 1\
+                                        WHEN 'GIVEN' THEN 2\
+                                        END,n.fullName] as output\
+                                        RETURN output[0] AS respondent_id, output[1] AS date,\
+                                        output[2] AS question_no, output[3] AS answer"
+
+QELO_TECHNOLOGY_BETWEEN_DATES_OPTIMIZED =   "MATCH (m:Employees)-[r]->(n:Technology)\
+                                            UNWIND r.learnt_dates\
+                                            AS learn WITH distinct(learn)\
+                                            WHERE date(learn)>=date($start_date)\
+                                            AND date(learn)<=date($end_date)\
+                                            MATCH (m:Employees)-[r]->(n:Technology)\
+                                            WHERE learn in r.learnt_dates\
+                                            WITH DISTINCT[m.ID,n.technology_name,learn] AS\
+                                            output RETURN output[0] AS respondent_id,\
+                                            output[1] AS technology,output[2] AS date"

--- a/backend/app/db/queries/cypher.py
+++ b/backend/app/db/queries/cypher.py
@@ -40,8 +40,8 @@ GET_USER_ID = "MATCH (e:Employees)\
                RETURN e.ID, e.email"
 
 GET_ACTIVE_USER_ID = "MATCH (e:Employees)\
-                       WHERE e.status='Y'\
-                       RETURN e.ID"
+                      WHERE e.status='Y'\
+                      RETURN e.ID"
 
 GET_USER_BY_EMAIL = "MATCH (e:Employees)\
                      WHERE e.email=$email\
@@ -52,23 +52,28 @@ SET_USER_STATUS = "MATCH (e:Employees)\
                    SET e.status=$status"
 
 GET_ACTIVE_USER_NAME = "MATCH (e:Employees)\
-                         WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
-                         RETURN e.fullName as name"
+                        WHERE e.status='Y'\
+                        AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
+                        RETURN e.fullName as name"
 
 GET_ACTIVE_USER_LIST = "MATCH (e:Employees)\
-                        WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
+                        WHERE e.status='Y'\
+                        AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
                         RETURN e.fullName as name, e.ID as id"
 
 GET_ACTIVE_USER_IDS = "MATCH (e:Employees)\
-                          WHERE e.status='Y' AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
-                          RETURN e.ID as id"
+                       WHERE e.status='Y'\
+                       AND NOT e.firstName IN ['','External','Edward','Shrihari','Kavitha']\
+                       RETURN e.ID as id"
 
 SET_GIVEN_PROP = "MATCH (a:Employees { fullName: $user_name })-[r:GIVEN]->(b:Employees { fullName: $helped_name })\
-                  WHERE NOT EXISTS(r.helpgiven) OR NOT $date in r.helpgiven\
+                  WHERE NOT EXISTS(r.helpgiven)\
+                  OR NOT $date in r.helpgiven\
                   SET r.helpgiven = coalesce(r.helpgiven, []) + $date"
 
 SET_TAKEN_PROP = "MATCH (a:Employees { fullName: $user_name })-[r:TAKEN]->(b:Employees { fullName: $helped_name })\
-                  WHERE NOT EXISTS(r.helptaken) OR NOT $date in r.helptaken\
+                  WHERE NOT EXISTS(r.helptaken)\
+                  OR NOT $date in r.helptaken\
                   SET r.helptaken = coalesce(r.helptaken, []) + $date"
 
 CREATE_TAKEN_REL = "MERGE (a:Employees { fullName: $user_name })\
@@ -87,7 +92,8 @@ SET_TECH_PROP = "MATCH (e:Employees { fullName: $name})-[z:KNOWS]-(t:Technology 
                  SET t.first_seen = $date_seen"
 
 SET_TECH_REL_PROP = "MATCH (e:Employees { fullName: $name})-[z:KNOWS]-(t:Technology { technology_name: $tech})\
-                     WHERE NOT EXISTS(z.learnt_dates) OR NOT $date in z.learnt_dates\
+                     WHERE NOT EXISTS(z.learnt_dates)\
+                     OR NOT $date in z.learnt_dates\
                      SET z.learnt_dates = coalesce(z.learnt_dates, []) + $date"
 
 CREATE_TECH_REL = "MERGE (e:Employees { fullName: $name})\
@@ -100,7 +106,8 @@ DELETE_USER = "MATCH (e:Employees { ID: $id })\
 GET_ALL_USERS = "MATCH (e:Employees)\
                  RETURN e ORDER BY e.ID"
 
-GET_USERS_BY_ID = "MATCH (e:Employees { ID: $id }) RETURN e"
+GET_USERS_BY_ID = "MATCH (e:Employees { ID: $id })\
+                   RETURN e"
 
 CHECK_IF_RESPONDED = [
     "MATCH (a:Employees)-[x:GIVEN]->(b:Employees) WHERE $date in x.helpgiven return a.ID",
@@ -109,51 +116,57 @@ CHECK_IF_RESPONDED = [
 ]
 
 TECHNOLOGIES_LEARNT_ON_PARTICULAR_WEEK = "MATCH (a:Employees)-[z:KNOWS]-(b:Technology)\
-                                           WHERE $date_monday in z.learnt_dates OR $date_friday in z.learnt_dates\
-                                           WITH DISTINCT[a.fullName,b.technology_name] AS output\
-                                           RETURN output[0] AS Name,output[1] AS Technology"
+                                          WHERE $date_monday in z.learnt_dates\
+                                          OR $date_friday in z.learnt_dates\
+                                          WITH DISTINCT[a.fullName,b.technology_name] AS output\
+                                          RETURN output[0] AS Name,output[1] AS Technology"
 
 QELO_TECHNOLOGY = "MATCH (m:Employees)-[r]->(n:Technology)\
                    RETURN m.ID AS respondent_id,n.technology_name AS technology,r.learnt_dates AS date"
 
-QELO_USERS = "MATCH (e:Employees) RETURN e.ID as id, e.firstName as first_name, e.lastName as last_name,\
+QELO_USERS = "MATCH (e:Employees)\
+              RETURN e.ID as id, e.firstName as first_name, e.lastName as last_name,\
               e.email as  email, e.author_name as author_name, e.status as active_flag"
 
-QELO_RESPONSE = "MATCH (m:Employees)-[r]->(n:Employees) RETURN m.ID AS respondent_id,\
+QELO_RESPONSE = "MATCH (m:Employees)-[r]->(n:Employees)\
+                 RETURN m.ID AS respondent_id,\
                  CASE type(r)\
-	             WHEN 'TAKEN' THEN r.helptaken\
-                 WHEN 'GIVEN' THEN r.helpgiven\
+                    WHEN 'TAKEN' THEN r.helptaken\
+                    WHEN 'GIVEN' THEN r.helpgiven\
                  END AS date,\
                  CASE type(r)\
-	             WHEN 'TAKEN' THEN 1\
-	             WHEN 'GIVEN' THEN 2\
-                 END AS question_no, n.fullName as answer"
+                    WHEN 'TAKEN' THEN 1\
+                    WHEN 'GIVEN' THEN 2\
+                 END AS question_no,\
+                 n.fullName as answer"
 
 #Query to get responses between two given dates
-QELO_RESPONSE_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Employees)\
-                                    UNWIND [r.helpgiven,r.helptaken] AS list_helpdates\
-                                    UNWIND list_helpdates AS helpdate\
-                                    WITH DISTINCT(helpdate)\
-                                    WHERE date(helpdate)>=date($start_date)\
-                                    AND date(helpdate)<=date($end_date)\
-                                    MATCH (m:Employees)-[r]->(n:Employees)\
-                                    WHERE helpdate IN r.helpgiven\
-                                    OR helpdate IN r.helptaken\
-                                    WITH DISTINCT[m.ID,helpdate,CASE type(r)\
+QELO_RESPONSE_BETWEEN_DATES =  "MATCH (m:Employees)-[r]->(n:Employees)\
+                                UNWIND [r.helpgiven,r.helptaken] AS list_helpdates\
+                                UNWIND list_helpdates AS helpdate\
+                                WITH DISTINCT(helpdate)\
+                                WHERE date(helpdate)>=date($start_date)\
+                                AND date(helpdate)<=date($end_date)\
+                                MATCH (m:Employees)-[r]->(n:Employees)\
+                                WHERE helpdate IN r.helpgiven\
+                                OR helpdate IN r.helptaken\
+                                WITH DISTINCT[m.ID,helpdate,\
+                                CASE type(r)\
                                     WHEN 'TAKEN' THEN 1\
                                     WHEN 'GIVEN' THEN 2\
-                                    END,n.fullName] AS output\
-                                    RETURN output[0] AS respondent_id, output[1] AS date,\
-                                    output[2] AS question_no, output[3] AS answer"
+                                END,\
+                                n.fullName] AS output\
+                                RETURN output[0] AS respondent_id, output[1] AS date,\
+                                output[2] AS question_no, output[3] AS answer"
 
 #Query to get  technologies learnt between two given dates
-QELO_TECHNOLOGY_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Technology)\
-                                    UNWIND r.learnt_dates\
-                                    AS learnt_date WITH DISTINCT(learnt_date)\
+QELO_TECHNOLOGY_BETWEEN_DATES =    "MATCH (m:Employees)-[r]->(n:Technology)\
+                                    UNWIND r.learnt_dates AS learnt_date\
+                                    WITH DISTINCT(learnt_date)\
                                     WHERE date(learnt_date)>=date($start_date)\
                                     AND date(learnt_date)<=date($end_date)\
                                     MATCH (m:Employees)-[r]->(n:Technology)\
                                     WHERE learnt_date IN r.learnt_dates\
-                                    WITH DISTINCT[m.ID,n.technology_name,learnt_date] AS\
-                                    output RETURN output[0] AS respondent_id,\
+                                    WITH DISTINCT[m.ID,n.technology_name,learnt_date] AS output\
+                                    RETURN output[0] AS respondent_id,\
                                     output[1] AS technology,output[2] AS date"

--- a/backend/app/db/queries/cypher.py
+++ b/backend/app/db/queries/cypher.py
@@ -127,62 +127,32 @@ QELO_RESPONSE = "MATCH (m:Employees)-[r]->(n:Employees) RETURN m.ID AS responden
 	             WHEN 'GIVEN' THEN 2\
                  END AS question_no, n.fullName as answer"
 
-QELO_RESPONSE_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Employees) WITH\
-                               CASE type(r)\
-                               WHEN 'GIVEN' THEN r.helpgiven\
-                               WHEN 'TAKEN' THEN r.helptaken\
-                               END AS dates\
-                               WITH dates UNWIND dates AS helpdate\
-                               WITH helpdate\
-                               WHERE date(helpdate)>=date($start_date)\
-                               AND date(helpdate)<=date($end_date)\
-                               MATCH (m:Employees)-[r]->(n:Employees)\
-                               WHERE helpdate in r.helpgiven\
-                               OR helpdate in r.helptaken\
-                               WITH distinct [m.ID,helpdate,CASE type(r)\
-                               WHEN 'TAKEN' THEN 1\
-                               WHEN 'GIVEN' THEN 2\
-                               END,n.fullName] as output\
-                               RETURN output[0] AS respondent_id, output[1] AS date,\
-                               output[2] AS question_no, output[3] AS answer"
+QELO_RESPONSE_BETWEEN_DATES =  "MATCH (m:Employees)-[r]->(n:Employees)\
+                                UNWIND [r.helpgiven,r.helptaken] AS list_helpdates\
+                                UNWIND list_helpdates as helpdate\
+                                WITH DISTINCT(helpdate)\
+                                WHERE date(helpdate)>=date($start_date)\
+                                AND date(helpdate)<=date($end_date)\
+                                MATCH (m:Employees)-[r]->(n:Employees)\
+                                WHERE helpdate in r.helpgiven\
+                                OR helpdate in r.helptaken\
+                                WITH distinct [m.ID,helpdate,CASE type(r)\
+                                WHEN 'TAKEN' THEN 1\
+                                WHEN 'GIVEN' THEN 2\
+                                END,n.fullName] as output\
+                                RETURN output[0] AS respondent_id, output[1] AS date,\
+                                output[2] AS question_no, output[3] AS answer"
 
-QELO_TECHNOLOGY_BETWEEN_DATES = "MATCH (m:Employees)-[r]->(n:Technology)\
-                                 WITH r.learnt_dates AS dates UNWIND dates\
-                                 AS learn WITH learn\
-                                 WHERE date(learn)>=date($start_date)\
-                                 AND date(learn)<=date($end_date)\
-                                 MATCH (m:Employees)-[r]->(n:Technology)\
-                                 WHERE learn in r.learnt_dates\
-                                 WITH DISTINCT[m.ID,n.technology_name,learn] AS\
-                                 output RETURN output[0] AS respondent_id,\
-                                 output[1] AS technology,output[2] AS date"
 
-QELO_RESPONSE_BETWEEN_DATES_OPTMIZED = "MATCH (m:Employees)-[r]->(n:Employees) WITH\
-                                        CASE type(r)\
-                                        WHEN 'GIVEN' THEN r.helpgiven\
-                                        WHEN 'TAKEN' THEN r.helptaken\
-                                        END AS dates\
-                                        WITH dates UNWIND dates AS helpdate\
-                                        WITH DISTINCT(helpdate)\
-                                        WHERE date(helpdate)>=date($start_date)\
-                                        AND date(helpdate)<=date($end_date)\
-                                        MATCH (m:Employees)-[r]->(n:Employees)\
-                                        WHERE helpdate in r.helpgiven\
-                                        OR helpdate in r.helptaken\
-                                        WITH distinct [m.ID,helpdate,CASE type(r)\
-                                        WHEN 'TAKEN' THEN 1\
-                                        WHEN 'GIVEN' THEN 2\
-                                        END,n.fullName] as output\
-                                        RETURN output[0] AS respondent_id, output[1] AS date,\
-                                        output[2] AS question_no, output[3] AS answer"
+QELO_TECHNOLOGY_BETWEEN_DATES =    "MATCH (m:Employees)-[r]->(n:Technology)\
+                                    UNWIND r.learnt_dates\
+                                    AS learn WITH distinct(learn)\
+                                    WHERE date(learn)>=date($start_date)\
+                                    AND date(learn)<=date($end_date)\
+                                    MATCH (m:Employees)-[r]->(n:Technology)\
+                                    WHERE learn in r.learnt_dates\
+                                    WITH DISTINCT[m.ID,n.technology_name,learn] AS\
+                                    output RETURN output[0] AS respondent_id,\
+                                    output[1] AS technology,output[2] AS date"
 
-QELO_TECHNOLOGY_BETWEEN_DATES_OPTIMIZED =   "MATCH (m:Employees)-[r]->(n:Technology)\
-                                            UNWIND r.learnt_dates\
-                                            AS learn WITH distinct(learn)\
-                                            WHERE date(learn)>=date($start_date)\
-                                            AND date(learn)<=date($end_date)\
-                                            MATCH (m:Employees)-[r]->(n:Technology)\
-                                            WHERE learn in r.learnt_dates\
-                                            WITH DISTINCT[m.ID,n.technology_name,learn] AS\
-                                            output RETURN output[0] AS respondent_id,\
-                                            output[1] AS technology,output[2] AS date"
+                                    


### PR DESCRIPTION
In this PR I have optimized the queries to fetch the employee responses between two given dates and the technologies learnt between two dates.
Earlier these queries used to take about 10 seconds each on an average to fetch the output, now after optimization it should take less than a second to fetch the results.
Files changed: 
`backend/app/db/queries/cypher.py`

Queries optimized:
`QELO_RESPONSE_BETWEEN_DATES`
`QELO_TECHNOLOGY_BETWEEN_DATES`
