### PR TITLE
Add smart wait to docker

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pytest>=7.2.0
 requests>=2.28.1
 python-decouple>=3.6
 pytest-xdist>=3.1.0
+wait-for-it>=2.2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,9 @@ services:
       - data:/data
       - logs:/logs
   python-app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: qxf2rohand/qxf2-survey-app:1.2
     depends_on:
       - neo-db
-    entrypoint: ["sh", "-c", "wait-for-it -t 180 -s bolt://neo-db:7687  -- echo 'Neo4j database is up' && (nohup uvicorn main:app --host 0.0.0.0 --reload &) && sleep 5 && cd /code/backend/db_backup_and_restore && python neo4j_restore.py && sleep 5 && cd /code/virtualized_employees_graphql_server && rm -rf ./node_modules && ln -s /code/mock_server_node_packages/node_modules/ . && (nohup node mock-graphql-server.js &) && cd /code/frontend && rm -rf ./node_modules && ln -s /code/react_node_packages/node_modules/ . && npm start"]
     ports:
       - "8000:8000"
       - "3000:3000/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,12 @@ services:
       - data:/data
       - logs:/logs
   python-app:
-    image: qxf2rohand/qxf2-survey-app:1.1
+    build:
+      context: .
+      dockerfile: Dockerfile
     depends_on:
       - neo-db
+    entrypoint: ["sh", "-c", "wait-for-it -t 180 -s bolt://neo-db:7687  -- echo 'Neo4j database is up' && (nohup uvicorn main:app --host 0.0.0.0 --reload &) && sleep 5 && cd /code/backend/db_backup_and_restore && python neo4j_restore.py && sleep 5 && cd /code/virtualized_employees_graphql_server && rm -rf ./node_modules && ln -s /code/mock_server_node_packages/node_modules/ . && (nohup node mock-graphql-server.js &) && cd /code/frontend && rm -rf ./node_modules && ln -s /code/react_node_packages/node_modules/ . && npm start"]
     ports:
       - "8000:8000"
       - "3000:3000/tcp"


### PR DESCRIPTION
Used 'wait-for-it' python library to add smart wait to qxf2 survey docker image. 
Earlier we were using a wait time of 15 seconds for the Neo4j Database to be up and running , but this was causing issues in a few systems as database setup took more than 15 seconds. 
With this smart wait feature the  Qxf2-survey container will execute only after the Neo4j DB is accessible.
The `wait-for-it` python library keeps pinging  the neo4j bolt port to see if it is accessible with a timeout period of 180 seconds. Once it is accessible the next commands ie: the operations on database, are performed 
