### PR TITLE
Fixed issue with integers getting converted to datetime object

### DIFF
--- a/backend/app/api/v1/routes/admin.py
+++ b/backend/app/api/v1/routes/admin.py
@@ -152,8 +152,14 @@ def technologies_learnt_on_week(fetched_date: schemas.FetchTechnology,
                                 authenticated: bool = Depends(security.validate_request)):
     "returns all the technologies learnt in the week for a given date"
     date = fetched_date.date
-    monday = date - timedelta(days=date.weekday())
-    friday = (date + relativedelta(weekday=FR(0))).strftime("%Y-%m-%d")
+    date_format = "%Y-%m-%d"
+    try:
+        datetime.strptime(str(date), date_format)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format. Please use YYYY-MM-DD format for start_date and end_date")
+    tech_date = datetime.strptime(date, date_format)
+    monday = tech_date - timedelta(days=tech_date.weekday())
+    friday = (tech_date + relativedelta(weekday=FR(0))).strftime("%Y-%m-%d")
     technologies = GRAPH.run(cypher.TECHNOLOGIES_LEARNT_ON_PARTICULAR_WEEK,
                              parameters={"date_monday":str(monday),
                              "date_friday":str(friday)}).data()
@@ -166,6 +172,13 @@ def qelo_get_response_between_given_dates(fetched_date: schemas.FetchResponses,
 
     start_date = fetched_date.start_date
     end_date = fetched_date.end_date
+    date_format = "%Y-%m-%d"
+    try:
+        datetime.strptime(str(start_date), date_format)
+        datetime.strptime(str(end_date), date_format)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format. Please use YYYY-MM-DD format for start_date and end_date")
+
     qelo_response = GRAPH.run(cypher.QELO_RESPONSE_BETWEEN_DATES,
                               parameters={"start_date":str(start_date),
                               "end_date":str(end_date)}).data()

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -3,7 +3,7 @@ This module models the api request bodies
 """
 
 from typing import Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import datetime
 
 class EmployeeData(BaseModel):
@@ -17,12 +17,12 @@ class EmployeeRegistration(BaseModel):
 
 class FetchTechnology(BaseModel):
     "request body"
-    date: datetime.date
+    date:str = Field(example="1980-01-25")
 
 class FetchResponses(BaseModel):
     "request body"
-    start_date: datetime.date
-    end_date: datetime.date
+    start_date: str = Field(example="1970-01-01")
+    end_date: str = Field(example="2023-01-01")
 
 class EmployeeEmail(BaseModel):
     "request body"


### PR DESCRIPTION
Modified API schema to use strings instead of date time objects. And added example of request body that can be used